### PR TITLE
[Fix] 배포 시 svg안나오는 문제 해결

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,18 @@ export default defineConfig({
         jpg: imageminMozjpeg(),
         png: imageminPngQuant(),
         gif: imageminGifSicle(),
-        svg: imageminSvgo(),
+        svg: imageminSvgo({
+          plugins: [
+            {
+              name: 'preset-default',
+              params: {
+                overrides: {
+                  removeViewBox: false,
+                },
+              },
+            },
+          ],
+        }),
       },
       makeWebp: {
         plugins: {


### PR DESCRIPTION
- 야무샘 답변 적용
- imageminSvgo플러그인이 최적화 시 viewBox를 삭제해서 발생하는 문제로 해당 기능을 off